### PR TITLE
feat(@rampant-wit/plugin): Save untrained responses to the database.

### DIFF
--- a/src/node_modules/@rampant-wit/plugin/index.js
+++ b/src/node_modules/@rampant-wit/plugin/index.js
@@ -63,13 +63,31 @@ export default ({ token, projectId, db } = {}) => {
                                           url: 'message',
                                           params: { q },
                                       })
+                                          .then(({ data }) => data.entities)
                                           .then(
-                                              ({ data }) =>
-                                                  data.entities.intent || [
-                                                      { value: 'Unknown' },
-                                                  ]
+                                              entities =>
+                                                  entities.intent
+                                                      ? entities
+                                                      : {
+                                                            ...entities,
+                                                            intent: [],
+                                                        }
                                           )
-                                          .then(i => i[0])
+                                          .then(
+                                              entities =>
+                                                  db
+                                                      .set(
+                                                          `projects/${projectId}/untrained/${q}`,
+                                                          entities
+                                                      )
+                                                      .then(() => entities) // eslint-disable-line max-nested-callbacks
+                                          )
+                                          .then(
+                                              ({ intent }) =>
+                                                  intent[0] || {
+                                                      value: 'Unknown',
+                                                  }
+                                          )
                                           .then(
                                               ({
                                                   value: intent,


### PR DESCRIPTION
Closes #615