### PR TITLE
refactor(dex-cli): Convert import winston to require to avoid interop.

### DIFF
--- a/src/node_modules/@dexterity/logger/index.js
+++ b/src/node_modules/@dexterity/logger/index.js
@@ -1,5 +1,6 @@
-import winston from 'winston'
 import { stringify } from 'javascript-stringify'
+
+const winston = require('winston')
 
 const { createLogger: createWinstonLogger, transports, format } = winston
 const { combine, timestamp, colorize, printf } = format


### PR DESCRIPTION
Interop was screwing things up since winston has a default property that is not exactly itself.