### PR TITLE
refactor(dex-cli): Convert require winston to import star.

### DIFF
--- a/src/node_modules/@dexterity/logger/index.js
+++ b/src/node_modules/@dexterity/logger/index.js
@@ -1,6 +1,5 @@
 import { stringify } from 'javascript-stringify'
-
-const winston = require('winston')
+import * as winston from 'winston'
 
 const { createLogger: createWinstonLogger, transports, format } = winston
 const { combine, timestamp, colorize, printf } = format


### PR DESCRIPTION
Kikd removed winston as an external dependency since it was not an import.