### PR TITLE
Support/incorrect diffs

### DIFF
--- a/src/node_modules/@kape/run-workload/index.js
+++ b/src/node_modules/@kape/run-workload/index.js
@@ -1,5 +1,6 @@
 import run from '@kape/run'
 import { read } from '@dev-xp/fs'
+import * as _ from '@dev-xp/utils'
 import { location as snapLocation, key as snapKey } from '@kape/snapshot-utils'
 
 const getPreviousSnapshots = suiteSnapshotFile =>
@@ -9,7 +10,8 @@ const getPreviousSnapshots = suiteSnapshotFile =>
             const generate = new Function('exports', contents)
             const snapshots = {}
             generate(snapshots)
-            return snapshots
+            const trimmed = _.map(_.trim, snapshots)
+            return trimmed
         })
         .catch(() => [])
 
@@ -21,7 +23,7 @@ const testSnapshots = previousSnapshots => result => ({
             ? true
             : previousSnapshots[snapKey(result)]
                 ? result.snapshot.trim() ===
-                  previousSnapshots[snapKey(result)].trim()
+              previousSnapshots[snapKey(result)].trim()
                 : false,
 })
 

--- a/src/node_modules/@kape/which-snapshot/index.js
+++ b/src/node_modules/@kape/which-snapshot/index.js
@@ -5,7 +5,7 @@ import prompt from '@kape/prompt'
 import { render as prettyPrint } from 'prettyjson'
 
 export default result => {
-    const { index, test, actual, snapshot } = result
+    const { index, suite, test, actual, snapshot } = result
     const { snapshotMatched, previousSnapshot } = result
 
     if (snapshotMatched) return Promise.resolve(result)
@@ -31,7 +31,7 @@ ${prettyPrint(actual)}
         default: false,
         message: chalk`${
             previousSnapshot ? 'Update' : 'ADD'
-        } [{reset.cyan ${test} #${index}}{white.bold ]?}`,
+        } [{reset.cyan ${suite}}{white.bold ] [}{reset.cyan ${test} #${index}}{white.bold ]?}`,
     }).then(answer => {
         if (answer === 'n' && !previousSnapshot) return undefined
         return answer === 'y'


### PR DESCRIPTION
Found the issue for #1265, however it unveiled that my handling of `falsey` values like `null`, `undefined`, and `''` needs to be handled better when storing snapshots and displaying the differences. SOOO this is a WIP until I get these tests green again.